### PR TITLE
Resolved 1 pipe limitation on WIN32 for Perl v5.20 and higher.

### DIFF
--- a/lib/Parallel/Pipes.pm
+++ b/lib/Parallel/Pipes.pm
@@ -135,6 +135,9 @@ our $VERSION = '0.004';
 
 sub new {
     my ($class, $number, $code) = @_;
+    if (WIN32 and $] lt '5.020000' and $number != 1) {
+        die "The number of pipes must be 1 under WIN32 Perl < v5.020 environment.\n";
+    }
     my $self = bless {
         code => $code,
         number => $number,

--- a/lib/Parallel/Pipes.pm
+++ b/lib/Parallel/Pipes.pm
@@ -136,7 +136,7 @@ our $VERSION = '0.004';
 sub new {
     my ($class, $number, $code) = @_;
     if (WIN32 and $] lt '5.020000' and $number != 1) {
-        die "The number of pipes must be 1 under WIN32 Perl < v5.020 environment.\n";
+        die "The number of pipes must be 1 under WIN32 Perl < v5.20 environment.\n";
     }
     my $self = bless {
         code => $code,


### PR DESCRIPTION
Hi @skaji,

I applied a fix so that this module allows multiple pipes/workers on WIN32 for Perl v5.20 and higher.

Regards,
Mario